### PR TITLE
Add SCSS config for GitPod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ logs
 
 # Ignore IDE specific files
 .idea/
-.vscode/
 
 # Ignore MacOS DS_Stores
 **/.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "liveSassCompile.settings.formats":[
+       {
+           "extensionName": ".css",
+           "format": "compressed",
+           "savePath": "/public_html/wp-content/themes/stcblog/"
+       }
+   ],
+   "liveSassCompile.settings.excludeList": [
+      "**/node_modules/**",
+      ".vscode/**"
+   ],
+   "liveSassCompile.settings.generateMap": true,
+   "liveSassCompile.settings.autoprefix": [
+       "> 1%",
+       "last 2 versions"
+   ]
+}


### PR DESCRIPTION
Add the necessary `.vscode/settings.json` with the proper config to use the [Live Sass Compiler](https://marketplace.visualstudio.com/items?itemName=glenn2223.live-sass) extension with our codebase when developing with GitPod or any VS Code installation.